### PR TITLE
feat: add manual photo grouping with pinned 3D-stack folders

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -636,6 +636,9 @@
   "collectionActionMove": "Move to album",
   "collectionActionRescan": "Rescan",
   "collectionActionEdit": "Edit",
+  "entryActionGroup": "Group",
+  "entryActionUngroup": "Ungroup",
+  "entryActionRemoveFromGroup": "Remove from group",
 
   "collectionSearchTitlesHintText": "Search titles",
 

--- a/lib/model/db/db.dart
+++ b/lib/model/db/db.dart
@@ -133,4 +133,24 @@ abstract class LocalMediaDb {
   Future<void> addVideoPlayback(Set<VideoPlaybackRow> rows);
 
   Future<void> removeVideoPlayback(Set<int> ids);
+
+  // entry groups
+
+  Future<List<Map<String, dynamic>>> loadAllEntryGroups();
+
+  Future<int> insertEntryGroup(Map<String, dynamic> groupMap);
+
+  Future<void> updateEntryGroup(Map<String, dynamic> groupMap);
+
+  Future<void> deleteEntryGroup(int groupId);
+
+  Future<List<Map<String, dynamic>>> loadEntryGroupMembers(int groupId);
+
+  Future<void> insertEntryGroupMember(int groupId, int entryId, int position);
+
+  Future<void> deleteEntryGroupMembers(int groupId, List<int> entryIds);
+
+  Future<int> getEntryGroupMemberCount(int groupId);
+
+  Future<List<Map<String, dynamic>>> loadAllEntryGroupMemberIds();
 }

--- a/lib/model/db/db_sqflite.dart
+++ b/lib/model/db/db_sqflite.dart
@@ -34,6 +34,8 @@ class SqfliteLocalMediaDb implements LocalMediaDb {
   static const vaultTable = SqfliteLocalMediaDbSchema.vaultTable;
   static const trashTable = SqfliteLocalMediaDbSchema.trashTable;
   static const videoPlaybackTable = SqfliteLocalMediaDbSchema.videoPlaybackTable;
+  static const entryGroupTable = SqfliteLocalMediaDbSchema.entryGroupTable;
+  static const entryGroupMemberTable = SqfliteLocalMediaDbSchema.entryGroupMemberTable;
 
   static const _entryInsertSliceMaxCount = 10000; // number of entries
   static const _queryCursorBufferSize = 1000; // number of rows
@@ -42,13 +44,23 @@ class SqfliteLocalMediaDb implements LocalMediaDb {
   @override
   int get nextId => ++_lastId;
 
+  Future<void>? _initFuture;
+
   @override
-  Future<void> init() async {
+  Future<void> init() {
+    _initFuture ??= _doInit();
+    return _initFuture!;
+  }
+
+  Future<void> _doInit() async {
     _db = await openDatabase(
       await path,
+      onConfigure: (db) async {
+        await db.execute('PRAGMA foreign_keys = ON');
+      },
       onCreate: (db, version) => SqfliteLocalMediaDbSchema.createLatestVersion(db),
       onUpgrade: LocalMediaDbUpgrader.upgradeDb,
-      version: 15,
+      version: 17,
     );
 
     final maxIdRows = await _db.rawQuery('SELECT MAX(id) AS maxId FROM $entryTable');
@@ -700,5 +712,113 @@ class SqfliteLocalMediaDb implements LocalMediaDb {
       }
     }
     return result;
+  }
+
+  // entry groups
+
+  @override
+  Future<List<Map<String, dynamic>>> loadAllEntryGroups() async {
+    final result = <Map<String, dynamic>>[];
+    final cursor = await _db.queryCursor(
+      entryGroupTable,
+      orderBy: 'dateCreatedMillis DESC',
+      bufferSize: _queryCursorBufferSize,
+    );
+    while (await cursor.moveNext()) {
+      result.add(Map.from(cursor.current));
+    }
+    return result;
+  }
+
+  @override
+  Future<int> insertEntryGroup(Map<String, dynamic> groupMap) async {
+    final id = await _db.insert(
+      entryGroupTable,
+      groupMap,
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+    return id;
+  }
+
+  @override
+  Future<void> updateEntryGroup(Map<String, dynamic> groupMap) async {
+    final id = groupMap['id'] as int?;
+    if (id == null) return;
+
+    await _db.update(
+      entryGroupTable,
+      groupMap,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  @override
+  Future<void> deleteEntryGroup(int groupId) async {
+    // CASCADE will auto-delete from entry_group_members
+    await _db.delete(
+      entryGroupTable,
+      where: 'id = ?',
+      whereArgs: [groupId],
+    );
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> loadEntryGroupMembers(int groupId) async {
+    // JOIN to get full entry data for group members
+    final rows = await _db.rawQuery('''
+      SELECT e.*
+      FROM $entryTable e
+      JOIN $entryGroupMemberTable gm ON e.id = gm.entryId
+      WHERE gm.groupId = ?
+      ORDER BY gm.position
+    ''', [groupId]);
+
+    return rows.map((row) => Map<String, dynamic>.from(row)).toList();
+  }
+
+  @override
+  Future<void> insertEntryGroupMember(int groupId, int entryId, int position) async {
+    await _db.insert(
+      entryGroupMemberTable,
+      {
+        'groupId': groupId,
+        'entryId': entryId,
+        'position': position,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  @override
+  Future<void> deleteEntryGroupMembers(int groupId, List<int> entryIds) async {
+    if (entryIds.isEmpty) return;
+
+    final batch = _db.batch();
+    for (final entryId in entryIds) {
+      batch.delete(
+        entryGroupMemberTable,
+        where: 'groupId = ? AND entryId = ?',
+        whereArgs: [groupId, entryId],
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  @override
+  Future<int> getEntryGroupMemberCount(int groupId) async {
+    final result = await _db.rawQuery(
+      'SELECT COUNT(*) as count FROM $entryGroupMemberTable WHERE groupId = ?',
+      [groupId],
+    );
+    return (result.firstOrNull?['count'] as int?) ?? 0;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> loadAllEntryGroupMemberIds() async {
+    return _db.query(
+      entryGroupMemberTable,
+      columns: ['groupId', 'entryId'],
+    );
   }
 }

--- a/lib/model/db/db_sqflite_schema.dart
+++ b/lib/model/db/db_sqflite_schema.dart
@@ -11,6 +11,8 @@ class SqfliteLocalMediaDbSchema {
   static const vaultTable = 'vaults';
   static const trashTable = 'trash';
   static const videoPlaybackTable = 'videoPlayback';
+  static const entryGroupTable = 'entry_groups';
+  static const entryGroupMemberTable = 'entry_group_members';
 
   static const allTables = [
     entryTable,
@@ -23,6 +25,8 @@ class SqfliteLocalMediaDbSchema {
     vaultTable,
     trashTable,
     videoPlaybackTable,
+    entryGroupTable,
+    entryGroupMemberTable,
   ];
 
   static Future<void> createLatestVersion(Database db) async {
@@ -110,6 +114,22 @@ class SqfliteLocalMediaDbSchema {
         return db.execute('CREATE TABLE $videoPlaybackTable('
             'id INTEGER PRIMARY KEY'
             ', resumeTimeMillis INTEGER'
+            ')');
+      case entryGroupTable:
+        return db.execute('CREATE TABLE $entryGroupTable('
+            'id INTEGER PRIMARY KEY AUTOINCREMENT'
+            ', name TEXT NOT NULL'
+            ', dateCreatedMillis INTEGER NOT NULL'
+            ', coverEntryId INTEGER'
+            ', sortOrder INTEGER DEFAULT 0'
+            ')');
+      case entryGroupMemberTable:
+        return db.execute('CREATE TABLE $entryGroupMemberTable('
+            'groupId INTEGER NOT NULL'
+            ', entryId INTEGER NOT NULL'
+            ', position INTEGER NOT NULL'
+            ', PRIMARY KEY (groupId, entryId)'
+            ', FOREIGN KEY (groupId) REFERENCES $entryGroupTable(id) ON DELETE CASCADE'
             ')');
       default:
         throw Exception('unknown table=$table');

--- a/lib/model/db/db_sqflite_upgrade.dart
+++ b/lib/model/db/db_sqflite_upgrade.dart
@@ -18,6 +18,8 @@ class LocalMediaDbUpgrader {
   static const vaultTable = SqfliteLocalMediaDbSchema.vaultTable;
   static const trashTable = SqfliteLocalMediaDbSchema.trashTable;
   static const videoPlaybackTable = SqfliteLocalMediaDbSchema.videoPlaybackTable;
+  static const entryGroupTable = SqfliteLocalMediaDbSchema.entryGroupTable;
+  static const entryGroupMemberTable = SqfliteLocalMediaDbSchema.entryGroupMemberTable;
 
   // warning: "ALTER TABLE ... RENAME COLUMN ..." is not supported
   // on SQLite <3.25.0, bundled on older Android devices
@@ -53,6 +55,9 @@ class LocalMediaDbUpgrader {
           await _upgradeFrom13(db);
         case 14:
           await _upgradeFrom14(db);
+        case 15:
+        case 16:
+          await _upgradeFrom15(db);
       }
       oldVersion++;
     }
@@ -499,5 +504,27 @@ class LocalMediaDbUpgrader {
     // transitional upgrade previously used to sanitize rebuildable tables
     // (dateTakenTable, metadataTable, addressTable, trashTable, videoPlaybackTable)
     // for users with a potentially corrupted DB following upgrade to v1.12.4
+  }
+
+  static Future<void> _upgradeFrom15(Database db) async {
+    debugPrint('upgrading DB from v15');
+
+    // new tables for manual photo grouping feature
+    await db.execute('CREATE TABLE IF NOT EXISTS $entryGroupTable ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT'
+        ', name TEXT NOT NULL'
+        ', dateCreatedMillis INTEGER NOT NULL'
+        ', coverEntryId INTEGER'
+        ', sortOrder INTEGER DEFAULT 0'
+        ')');
+
+    await db.execute('CREATE TABLE IF NOT EXISTS $entryGroupMemberTable ('
+        'groupId INTEGER NOT NULL'
+        ', entryId INTEGER NOT NULL'
+        ', position INTEGER NOT NULL'
+        ', PRIMARY KEY (groupId, entryId)'
+        ', FOREIGN KEY (groupId) REFERENCES $entryGroupTable(id) ON DELETE CASCADE'
+        ', FOREIGN KEY (entryId) REFERENCES entry(id) ON DELETE CASCADE'
+        ')');
   }
 }

--- a/lib/model/entry/entry.dart
+++ b/lib/model/entry/entry.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:aves/model/entry/cache.dart';
 import 'package:aves/model/entry/dirs.dart';
+import 'package:aves/model/entry/entry_group.dart';
 import 'package:aves/model/entry/extensions/keys.dart';
 import 'package:aves/model/metadata/address.dart';
 import 'package:aves/model/metadata/catalog.dart';
@@ -48,6 +49,9 @@ class AvesEntry with AvesEntryBase {
   // synthetic stack of related entries, e.g. burst shots or raw/developed pairs
   List<AvesEntry>? stackedEntries;
 
+  // manual group this entry represents (if it's a group cover)
+  EntryGroup? entryGroup;
+
   @override
   final AChangeNotifier visualChangeNotifier = AChangeNotifier();
 
@@ -72,6 +76,7 @@ class AvesEntry with AvesEntryBase {
     required this.trashed,
     required this.origin,
     this.stackedEntries,
+    this.entryGroup,
   }) : id = id ?? 0 {
     if (kFlutterMemoryAllocationsEnabled) {
       LeakTracking.dispatchObjectCreated(
@@ -96,6 +101,7 @@ class AvesEntry with AvesEntryBase {
     int? dateModifiedMillis,
     int? origin,
     List<AvesEntry>? stackedEntries,
+    EntryGroup? entryGroup,
   }) {
     final copyEntryId = id ?? this.id;
     final copied = AvesEntry(
@@ -117,6 +123,7 @@ class AvesEntry with AvesEntryBase {
       trashed: trashed,
       origin: origin ?? this.origin,
       stackedEntries: stackedEntries ?? this.stackedEntries,
+      entryGroup: entryGroup ?? this.entryGroup,
     )
       ..catalogMetadata = _catalogMetadata?.copyWith(id: copyEntryId)
       ..addressDetails = _addressDetails?.copyWith(id: copyEntryId)

--- a/lib/model/entry/entry_group.dart
+++ b/lib/model/entry/entry_group.dart
@@ -1,0 +1,222 @@
+import 'package:aves/model/entry/entry.dart';
+import 'package:flutter/foundation.dart';
+
+/// Represents a manually created group of photos.
+/// Groups allow users to organize related photos together without
+/// moving them into separate albums.
+class EntryGroup with ChangeNotifier {
+  /// Unique identifier for this group (database ID)
+  int? id;
+
+  /// User-defined name for the group (e.g., "Island 2023", "Bike Sale")
+  String name;
+
+  /// Timestamp when the group was created (milliseconds since epoch)
+  final int dateCreatedMillis;
+
+  /// ID of the entry to use as the cover/thumbnail for this group
+  /// If null, the first entry in the group is used
+  int? coverEntryId;
+
+  /// Sort order for displaying groups (lower numbers appear first)
+  int sortOrder;
+
+  /// In-memory cache of group members
+  /// Loaded lazily to avoid performance issues with large groups
+  List<AvesEntry> _members = [];
+
+  /// IDs of all members in the group
+  Set<int> _memberIds = {};
+
+  /// Indicates whether the members list has been loaded from the database
+  bool _membersLoaded = false;
+
+  EntryGroup({
+    this.id,
+    required this.name,
+    required this.dateCreatedMillis,
+    this.coverEntryId,
+    this.sortOrder = 0,
+    List<AvesEntry>? members,
+    Set<int>? memberIds,
+  }) {
+    if (members != null) {
+      _members = members;
+      _memberIds = members.map((e) => e.id).toSet();
+      _membersLoaded = true;
+    } else if (memberIds != null) {
+      _memberIds = memberIds;
+    }
+  }
+
+  /// Returns IDs of all members
+  Set<int> get memberIds => Set.unmodifiable(_memberIds);
+
+  /// Returns an unmodifiable view of the group members
+  List<AvesEntry> get members => List.unmodifiable(_members);
+
+  /// Returns the number of photos in this group
+  int get memberCount => _membersLoaded ? _members.length : _memberIds.length;
+
+  /// Returns true if the members list has been loaded
+  bool get isMembersLoaded => _membersLoaded;
+
+  /// Returns the entry to use as the cover/thumbnail
+  /// Falls back to the first entry if coverEntryId is not set or not found
+  AvesEntry? get coverEntry {
+    if (coverEntryId != null && _members.isNotEmpty) {
+      try {
+        return _members.firstWhere((e) => e.id == coverEntryId);
+      } catch (_) {
+        // coverEntryId not found, fall through to default
+      }
+    }
+    return _members.isNotEmpty ? _members.first : null;
+  }
+
+  /// Sets the members list (typically called after loading from database)
+  void setMembers(List<AvesEntry> entries) {
+    _members = entries;
+    _memberIds = entries.map((e) => e.id).toSet();
+    _membersLoaded = true;
+    notifyListeners();
+  }
+
+  /// Adds a member to the group
+  void addMember(AvesEntry entry) {
+    if (!_members.contains(entry)) {
+      _members.add(entry);
+      _memberIds.add(entry.id);
+      notifyListeners();
+    }
+  }
+
+  /// Adds multiple members to the group
+  void addMembers(List<AvesEntry> entries) {
+    bool changed = false;
+    for (final entry in entries) {
+      if (!_members.contains(entry)) {
+        _members.add(entry);
+        changed = true;
+      }
+    }
+    if (changed) {
+      _memberIds.addAll(entries.map((e) => e.id));
+      notifyListeners();
+    }
+  }
+
+  /// Removes a member from the group
+  void removeMember(AvesEntry entry) {
+    if (_members.remove(entry)) {
+      _memberIds.remove(entry.id);
+      // If the removed entry was the cover, reset cover to null
+      // (will automatically use first entry)
+      if (coverEntryId == entry.id) {
+        coverEntryId = null;
+      }
+      notifyListeners();
+    }
+  }
+
+  /// Removes multiple members from the group
+  void removeMembers(List<int> entryIds) {
+    final originalLength = _members.length;
+    for (final id in entryIds) {
+      _members.removeWhere((e) => e.id == id);
+      _memberIds.remove(id);
+      if (coverEntryId == id) {
+        coverEntryId = null;
+      }
+    }
+    if (_members.length != originalLength) {
+      notifyListeners();
+    }
+  }
+
+  /// Updates the cover photo for this group
+  void updateCover(AvesEntry entry) {
+    if (_members.contains(entry)) {
+      coverEntryId = entry.id;
+      notifyListeners();
+    }
+  }
+
+  /// Reorders the members list
+  void reorderMembers(int oldIndex, int newIndex) {
+    if (oldIndex < newIndex) {
+      newIndex -= 1;
+    }
+    final entry = _members.removeAt(oldIndex);
+    _members.insert(newIndex, entry);
+    notifyListeners();
+  }
+
+  /// Converts this group to a Map for database storage
+  Map<String, dynamic> toMap() {
+    return {
+      EntryGroupFields.id: id,
+      EntryGroupFields.name: name,
+      EntryGroupFields.dateCreatedMillis: dateCreatedMillis,
+      EntryGroupFields.coverEntryId: coverEntryId,
+      EntryGroupFields.sortOrder: sortOrder,
+    };
+  }
+
+  /// Creates an EntryGroup from a database Map
+  factory EntryGroup.fromMap(Map<String, dynamic> map) {
+    return EntryGroup(
+      id: map[EntryGroupFields.id] as int?,
+      name: map[EntryGroupFields.name] as String,
+      dateCreatedMillis: map[EntryGroupFields.dateCreatedMillis] as int,
+      coverEntryId: map[EntryGroupFields.coverEntryId] as int?,
+      sortOrder: map[EntryGroupFields.sortOrder] as int? ?? 0,
+    );
+  }
+
+  /// Creates a copy of this group with the specified fields updated
+  EntryGroup copyWith({
+    int? id,
+    String? name,
+    int? dateCreatedMillis,
+    int? coverEntryId,
+    int? sortOrder,
+    List<AvesEntry>? members,
+    Set<int>? memberIds,
+  }) {
+    return EntryGroup(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      dateCreatedMillis: dateCreatedMillis ?? this.dateCreatedMillis,
+      coverEntryId: coverEntryId ?? this.coverEntryId,
+      sortOrder: sortOrder ?? this.sortOrder,
+      members: members ?? _members,
+      memberIds: memberIds ?? members?.map((e) => e.id).toSet() ?? _memberIds,
+    );
+  }
+
+  @override
+  String toString() => 'EntryGroup{id: $id, name: $name, memberCount: $memberCount}';
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EntryGroup && runtimeType == other.runtimeType && id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}
+
+/// Field names for the entry_groups database table
+class EntryGroupFields {
+  static const String id = 'id';
+  static const String name = 'name';
+  static const String dateCreatedMillis = 'dateCreatedMillis';
+  static const String coverEntryId = 'coverEntryId';
+  static const String sortOrder = 'sortOrder';
+}
+
+/// Field names for the entry_group_members database table
+class EntryGroupMemberFields {
+  static const String groupId = 'groupId';
+  static const String entryId = 'entryId';
+  static const String position = 'position';
+}

--- a/lib/model/filters/entry_group.dart
+++ b/lib/model/filters/entry_group.dart
@@ -1,0 +1,53 @@
+import 'package:aves/model/entry/entry.dart';
+import 'package:aves/model/filters/filters.dart';
+import 'package:aves/services/common/entry_group_service.dart';
+import 'package:aves/theme/icons.dart';
+import 'package:flutter/widgets.dart';
+
+class EntryGroupFilter extends CollectionFilter {
+  static const type = 'entry_group';
+
+  final int groupId;
+  final String groupName;
+
+  @override
+  List<Object?> get props => [groupId, reversed];
+
+  const EntryGroupFilter(this.groupId, this.groupName, {super.reversed = false});
+
+  factory EntryGroupFilter.fromMap(Map<String, dynamic> jsonMap) {
+    return EntryGroupFilter(
+      jsonMap['groupId'] as int,
+      jsonMap['groupName'] as String,
+      reversed: jsonMap['reversed'] as bool? ?? false,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toMap() => {
+        'type': type,
+        'groupId': groupId,
+        'groupName': groupName,
+        'reversed': reversed,
+      };
+
+  @override
+  EntryPredicate get positiveTest {
+    return (AvesEntry entry) => EntryGroupService().getGroupMemberIds(groupId).contains(entry.id);
+  }
+
+  @override
+  bool get exclusiveProp => true;
+
+  @override
+  String get universalLabel => groupName;
+
+  @override
+  String get key => '$type-$groupId';
+
+  @override
+  String get category => type;
+
+  @override
+  Widget? iconBuilder(BuildContext context, double size, {bool allowGenericIcon = true}) => Icon(AIcons.group, size: size);
+}

--- a/lib/model/filters/filters.dart
+++ b/lib/model/filters/filters.dart
@@ -12,6 +12,7 @@ import 'package:aves/model/filters/covered/location.dart';
 import 'package:aves/model/filters/covered/stored_album.dart';
 import 'package:aves/model/filters/covered/tag.dart';
 import 'package:aves/model/filters/date.dart';
+import 'package:aves/model/filters/entry_group.dart';
 import 'package:aves/model/filters/favourite.dart';
 import 'package:aves/model/filters/mime.dart';
 import 'package:aves/model/filters/missing.dart';
@@ -34,6 +35,7 @@ import 'package:provider/provider.dart';
 abstract class CollectionFilter extends Equatable implements Comparable<CollectionFilter> {
   static const List<String> categoryOrder = [
     TrashFilter.type,
+    EntryGroupFilter.type,
     QueryFilter.type,
     SetAndFilter.type,
     SetOrFilter.type,
@@ -77,6 +79,8 @@ abstract class CollectionFilter extends Equatable implements Comparable<Collecti
         return DynamicAlbumFilter.fromMap(jsonMap);
       case FavouriteFilter.type:
         return FavouriteFilter.fromMap(jsonMap);
+      case EntryGroupFilter.type:
+        return EntryGroupFilter.fromMap(jsonMap);
       case LocationFilter.type:
         return LocationFilter.fromMap(jsonMap);
       case MimeFilter.type:

--- a/lib/model/source/collection_lens.dart
+++ b/lib/model/source/collection_lens.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:aves/model/entry/entry.dart';
+import 'package:aves/model/entry/entry_group.dart';
 import 'package:aves/model/entry/extensions/multipage.dart';
 import 'package:aves/model/entry/extensions/props.dart';
 import 'package:aves/model/entry/sort.dart';
@@ -9,6 +10,7 @@ import 'package:aves/model/favourites.dart';
 import 'package:aves/model/filters/covered/location.dart';
 import 'package:aves/model/filters/covered/stored_album.dart';
 import 'package:aves/model/filters/favourite.dart';
+import 'package:aves/model/filters/entry_group.dart';
 import 'package:aves/model/filters/filters.dart';
 import 'package:aves/model/filters/query.dart';
 import 'package:aves/model/filters/rating.dart';
@@ -23,6 +25,7 @@ import 'package:aves/ref/mime_types.dart';
 import 'package:aves/utils/collection_utils.dart';
 import 'package:aves_model/aves_model.dart';
 import 'package:aves_utils/aves_utils.dart';
+import 'package:aves/services/common/entry_group_service.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -86,6 +89,13 @@ class CollectionLens with ChangeNotifier {
         }
       }));
       favourites.addListener(_onFavouritesChanged);
+
+      final entryGroupService = EntryGroupService();
+      _subscriptions.add(entryGroupService.eventBus.on<EntryGroupCreatedEvent>().listen((e) => refresh()));
+      _subscriptions.add(entryGroupService.eventBus.on<EntryGroupUpdatedEvent>().listen((e) => refresh()));
+      _subscriptions.add(entryGroupService.eventBus.on<EntryGroupDeletedEvent>().listen((e) => refresh()));
+      _subscriptions.add(entryGroupService.eventBus.on<EntryGroupMembersAddedEvent>().listen((e) => refresh()));
+      _subscriptions.add(entryGroupService.eventBus.on<EntryGroupMembersRemovedEvent>().listen((e) => refresh()));
     }
     _subscriptions.add(settings.updateStream
         .where((event) => [
@@ -200,12 +210,66 @@ class CollectionLens with ChangeNotifier {
     _disposeSyntheticEntries();
     _filteredSortedEntries = List.of(filters.isEmpty ? entries : entries.where((entry) => filters.every((filter) => filter.test(entry))));
 
-    if (stackBursts) {
-      _stackBursts();
+    if (filters.isEmpty) {
+      _stackManualGroups();
     }
-    if (stackDevelopedRaws) {
-      _stackDevelopedRaws();
+  }
+
+  void _stackManualGroups() {
+    if (!EntryGroupService().isInitialized) {
+      unawaited(EntryGroupService().getAllGroups().then((_) {
+        refresh();
+      }));
+      return;
     }
+
+    final groups = EntryGroupService().cachedGroups;
+    if (groups.isEmpty) return;
+
+    // Optimize lookup: map entryId -> group
+    final entryToGroup = <int, EntryGroup>{};
+    for (final group in groups) {
+      // Skip stacking if we are explicitly viewing this group
+      if (filters.any((f) => f is EntryGroupFilter && f.groupId == group.id)) {
+        continue;
+      }
+      for (final id in group.memberIds) {
+        entryToGroup[id] = group;
+      }
+    }
+
+    if (entryToGroup.isEmpty) return;
+
+    final entriesByGroup = <int, List<AvesEntry>>{};
+    for (final entry in _filteredSortedEntries) {
+      final group = entryToGroup[entry.id];
+      if (group != null) {
+        entriesByGroup.putIfAbsent(group.id!, () => []).add(entry);
+      }
+    }
+
+    final manualGroupEntries = <AvesEntry>[];
+    final allGroupMemberIds = entryToGroup.keys.toSet();
+
+    for (var groupId in entriesByGroup.keys) {
+      final groupEntries = entriesByGroup[groupId]!;
+      final group = entryToGroup[groupEntries.first.id]!;
+
+      if (groupEntries.isNotEmpty) {
+        final coverEntry = groupEntries.firstWhereOrNull((e) => e.id == group.coverEntryId) ?? groupEntries.first;
+
+        final groupEntry = coverEntry.copyWith(
+          entryGroup: group,
+          stackedEntries: groupEntries,
+        );
+        _syntheticEntries.add(groupEntry);
+        manualGroupEntries.add(groupEntry);
+      }
+    }
+
+    // Remove all members and prepend the group entries to pin them at the top
+    _filteredSortedEntries.removeWhere((entry) => allGroupMemberIds.contains(entry.id));
+    _filteredSortedEntries.insertAll(0, manualGroupEntries);
   }
 
   void _stackBursts() {

--- a/lib/model/source/collection_source.dart
+++ b/lib/model/source/collection_source.dart
@@ -19,6 +19,7 @@ import 'package:aves/model/grouping/convert.dart';
 import 'package:aves/model/metadata/trash.dart';
 import 'package:aves/model/settings/settings.dart';
 import 'package:aves/model/source/album.dart';
+import 'package:aves/model/source/manual_group.dart';
 import 'package:aves/model/source/analysis_controller.dart';
 import 'package:aves/model/source/events.dart';
 import 'package:aves/model/source/location/country.dart';
@@ -29,6 +30,7 @@ import 'package:aves/model/source/tag.dart';
 import 'package:aves/model/source/trash.dart';
 import 'package:aves/model/vaults/vaults.dart';
 import 'package:aves/services/analysis_service.dart';
+import 'package:aves/services/common/entry_group_service.dart';
 import 'package:aves/services/common/image_op_events.dart';
 import 'package:aves/services/common/services.dart';
 import 'package:aves/widgets/aves_app.dart';
@@ -68,7 +70,7 @@ mixin SourceBase {
   void invalidateEntries();
 }
 
-abstract class CollectionSource with SourceBase, AlbumMixin, CountryMixin, PlaceMixin, StateMixin, LocationMixin, TagMixin, TrashMixin {
+abstract class CollectionSource with SourceBase, AlbumMixin, CountryMixin, PlaceMixin, StateMixin, LocationMixin, TagMixin, TrashMixin, ManualGroupMixin {
   static const fullScope = <CollectionFilter>{};
 
   CollectionSource() {
@@ -89,6 +91,11 @@ abstract class CollectionSource with SourceBase, AlbumMixin, CountryMixin, Place
       }
     });
     vaults.addListener(_onVaultsChanged);
+    _groupSubscriptions.add(entryGroupService.eventBus.on<EntryGroupCreatedEvent>().listen((_) => _onManualGroupChanged()));
+    _groupSubscriptions.add(entryGroupService.eventBus.on<EntryGroupDeletedEvent>().listen((_) => _onManualGroupChanged()));
+    _groupSubscriptions.add(entryGroupService.eventBus.on<EntryGroupUpdatedEvent>().listen((_) => _onManualGroupChanged()));
+    _groupSubscriptions.add(entryGroupService.eventBus.on<EntryGroupMembersAddedEvent>().listen((_) => _onManualGroupChanged()));
+    _groupSubscriptions.add(entryGroupService.eventBus.on<EntryGroupMembersRemovedEvent>().listen((_) => _onManualGroupChanged()));
   }
 
   @mustCallSuper
@@ -97,10 +104,13 @@ abstract class CollectionSource with SourceBase, AlbumMixin, CountryMixin, Place
       LeakTracking.dispatchObjectDisposed(object: this);
     }
     vaults.removeListener(_onVaultsChanged);
+    _groupSubscriptions.forEach((sub) => sub.cancel());
     _rawEntries.forEach((v) => v.dispose());
   }
 
   set canAnalyze(bool enabled);
+
+  final List<StreamSubscription> _groupSubscriptions = [];
 
   final EventBus _eventBus = EventBus();
 
@@ -144,6 +154,7 @@ abstract class CollectionSource with SourceBase, AlbumMixin, CountryMixin, Place
 
   Future<void> loadDates() async {
     _savedDates = Map.unmodifiable(await localMediaDb.loadDates());
+    updateManualGroups();
   }
 
   Set<CollectionFilter> _getAppHiddenFilters() => {
@@ -630,6 +641,12 @@ abstract class CollectionSource with SourceBase, AlbumMixin, CountryMixin, Place
   void _onVaultsChanged() {
     final newlyVisibleFilters = vaults.vaultDirectories.whereNot(vaults.isLocked).map((v) => StoredAlbumFilter(v, null)).toSet();
     _onFilterVisibilityChanged(newlyVisibleFilters);
+  }
+
+  void _onManualGroupChanged() {
+    updateManualGroups();
+    _invalidate();
+    eventBus.fire(EntryRefreshedEvent(allEntries)); // Or just something to trigger UI refresh
   }
 }
 

--- a/lib/model/source/manual_group.dart
+++ b/lib/model/source/manual_group.dart
@@ -1,0 +1,28 @@
+import 'package:aves/model/source/collection_source.dart';
+import 'package:aves/services/common/entry_group_service.dart';
+
+mixin ManualGroupMixin on SourceBase {
+  void updateManualGroups() {
+    final service = EntryGroupService();
+    final groups = service.cachedGroups;
+
+    // Clear existing group flags
+    for (final entry in allEntries) {
+      entry.entryGroup = null;
+    }
+
+    for (final group in groups) {
+      int? coverId = group.coverEntryId;
+      if (coverId == null && group.memberIds.isNotEmpty) {
+        coverId = group.memberIds.first; // Or last, depending on preference
+      }
+
+      if (coverId != null) {
+        final entry = entryById[coverId];
+        if (entry != null) {
+          entry.entryGroup = group;
+        }
+      }
+    }
+  }
+}

--- a/lib/services/common/entry_group_service.dart
+++ b/lib/services/common/entry_group_service.dart
@@ -1,0 +1,346 @@
+import 'dart:async';
+
+import 'package:aves/model/entry/entry.dart';
+import 'package:aves/model/entry/entry_group.dart';
+import 'package:aves/services/common/services.dart';
+import 'package:event_bus/event_bus.dart';
+import 'package:flutter/foundation.dart';
+
+/// Service for managing photo groups.
+/// Handles CRUD operations, persistence, and event notifications.
+class EntryGroupService with ChangeNotifier {
+  static final EntryGroupService _instance = EntryGroupService._internal();
+  factory EntryGroupService() => _instance;
+  EntryGroupService._internal();
+
+  final EventBus eventBus = EventBus();
+
+  /// In-memory cache of all groups
+  final Map<int, EntryGroup> _groupsById = {};
+
+  /// Flag indicating whether groups have been loaded from database
+  bool _isInitialized = false;
+
+  /// Returns cached groups synchronously
+  List<EntryGroup> get cachedGroups => _groupsById.values.toList()..sort((a, b) => b.dateCreatedMillis.compareTo(a.dateCreatedMillis));
+
+  bool get isInitialized => _isInitialized;
+
+  /// Returns member IDs for a group synchronously from cache
+  Set<int> getGroupMemberIds(int groupId) {
+    return _groupsById[groupId]?.memberIds ?? {};
+  }
+
+  Future<void>? _initFuture;
+
+  /// Returns all groups, loading from database if necessary
+  Future<List<EntryGroup>> getAllGroups() async {
+    if (!_isInitialized) {
+      _initFuture ??= _loadGroups();
+      await _initFuture;
+    }
+    return _groupsById.values.toList()..sort((a, b) => b.dateCreatedMillis.compareTo(a.dateCreatedMillis));
+  }
+
+  /// Returns a specific group by ID
+  Future<EntryGroup?> getGroup(int groupId) async {
+    if (!_isInitialized) {
+      await _loadGroups();
+    }
+    return _groupsById[groupId];
+  }
+
+  /// Creates a new group with the specified entries
+  Future<EntryGroup> createGroup({
+    required String name,
+    required List<AvesEntry> entries,
+    int? coverEntryId,
+  }) async {
+    if (entries.isEmpty) {
+      throw ArgumentError('Cannot create group with no entries');
+    }
+
+    // Ensure only entries with valid IDs are grouped
+    final validEntries = entries.toList();
+    if (validEntries.isEmpty) {
+      throw ArgumentError('None of the selected entries have a database ID. Please wait for cataloguing to finish.');
+    }
+
+    // Ensure we are initialized so we can access the DB
+    await getAllGroups();
+
+    final group = EntryGroup(
+      name: name,
+      dateCreatedMillis: DateTime.now().millisecondsSinceEpoch,
+      coverEntryId: coverEntryId,
+      members: validEntries,
+    );
+
+    // Save to database
+    final groupId = await _saveGroupToDb(group, validEntries);
+    group.id = groupId;
+
+    // Add to cache
+    _groupsById[groupId] = group;
+
+    // Notify listeners
+    notifyListeners();
+    eventBus.fire(EntryGroupCreatedEvent(group));
+
+    debugPrint('Created group: ${group.name} with ${validEntries.length} entries (ID: ${group.id})');
+    return group;
+  }
+
+  /// Updates an existing group's metadata
+  Future<void> updateGroup(EntryGroup group) async {
+    if (group.id == null) {
+      throw ArgumentError('Cannot update group without ID');
+    }
+
+    // Update in database
+    await _updateGroupInDb(group);
+
+    // Update cache
+    _groupsById[group.id!] = group;
+
+    // Notify listeners
+    notifyListeners();
+    eventBus.fire(EntryGroupUpdatedEvent(group));
+
+    debugPrint('Updated group: ${group.name}');
+  }
+
+  /// Renames a group
+  Future<void> renameGroup(int groupId, String newName) async {
+    final group = await getGroup(groupId);
+    if (group == null) {
+      throw ArgumentError('Group not found: $groupId');
+    }
+
+    final updatedGroup = group.copyWith(name: newName);
+    await updateGroup(updatedGroup);
+  }
+
+  /// Deletes a group (photos remain in the gallery)
+  Future<void> deleteGroup(int groupId) async {
+    final group = _groupsById[groupId];
+    if (group == null) return;
+
+    // Delete from database
+    await _deleteGroupFromDb(groupId);
+
+    // Remove from cache
+    _groupsById.remove(groupId);
+
+    // Notify listeners
+    notifyListeners();
+    eventBus.fire(EntryGroupDeletedEvent(group));
+
+    debugPrint('Deleted group: ${group.name}');
+  }
+
+  /// Adds entries to an existing group
+  Future<void> addEntriesToGroup({
+    required int groupId,
+    required List<AvesEntry> entries,
+  }) async {
+    final group = await getGroup(groupId);
+    if (group == null) {
+      throw ArgumentError('Group not found: $groupId');
+    }
+
+    // Add entries to group
+    group.addMembers(entries);
+
+    // Save to database
+    await _addMembersToDb(groupId, entries);
+
+    // Notify listeners
+    notifyListeners();
+    eventBus.fire(EntryGroupMembersAddedEvent(group, entries));
+
+    debugPrint('Added ${entries.length} entries to group: ${group.name}');
+  }
+
+  /// Removes entries from a group
+  Future<void> removeEntriesFromGroup({
+    required int groupId,
+    required List<int> entryIds,
+  }) async {
+    final group = await getGroup(groupId);
+    if (group == null) return;
+
+    // Remove entries from group
+    group.removeMembers(entryIds);
+
+    // Update database
+    await _removeMembersFromDb(groupId, entryIds);
+
+    // If group is now empty, delete it
+    if (group.memberCount == 0) {
+      await deleteGroup(groupId);
+    } else {
+      // Notify listeners
+      notifyListeners();
+      eventBus.fire(EntryGroupMembersRemovedEvent(group, entryIds));
+    }
+
+    debugPrint('Removed ${entryIds.length} entries from group: ${group.name}');
+  }
+
+  /// Returns all group members for a specific group
+  Future<List<AvesEntry>> getGroupMembers(int groupId) async {
+    final group = await getGroup(groupId);
+    if (group == null) return [];
+
+    // Load members if not already loaded
+    if (!group.isMembersLoaded) {
+      final members = await _loadGroupMembersFromDb(groupId);
+      group.setMembers(members);
+    }
+
+    return group.members;
+  }
+
+  /// Returns all groups that contain a specific entry
+  Future<List<EntryGroup>> getGroupsContainingEntry(int entryId) async {
+    await getAllGroups(); // Ensure groups are loaded
+
+    final containingGroups = <EntryGroup>[];
+    for (final group in _groupsById.values) {
+      // Load members if necessary
+      if (!group.isMembersLoaded) {
+        await getGroupMembers(group.id!);
+      }
+
+      if (group.members.any((e) => e.id == entryId)) {
+        containingGroups.add(group);
+      }
+    }
+
+    return containingGroups;
+  }
+
+  /// Returns true if an entry is in any group
+  Future<bool> isEntryInAnyGroup(int entryId) async {
+    final groups = await getGroupsContainingEntry(entryId);
+    return groups.isNotEmpty;
+  }
+
+  /// Handles when an entry is deleted from the device
+  /// Removes it from all groups and deletes empty groups
+  Future<void> onEntryDeleted(AvesEntry entry) async {
+    final groups = await getGroupsContainingEntry(entry.id);
+
+    for (final group in groups) {
+      await removeEntriesFromGroup(
+        groupId: group.id!,
+        entryIds: [entry.id],
+      );
+    }
+  }
+
+  /// Handles when multiple entries are deleted
+  Future<void> onEntriesDeleted(List<AvesEntry> entries) async {
+    for (final entry in entries) {
+      await onEntryDeleted(entry);
+    }
+  }
+
+  // Private database methods (to be implemented)
+
+  Future<void> _loadGroups() async {
+    debugPrint('Loading groups from database...');
+    await localMediaDb.init();
+
+    final maps = await localMediaDb.loadAllEntryGroups();
+    final memberIdsRows = await localMediaDb.loadAllEntryGroupMemberIds();
+
+    // Process member IDs
+    final groupMembers = <int, Set<int>>{};
+    for (final row in memberIdsRows) {
+      final groupId = row['groupId'] as int;
+      final entryId = row['entryId'] as int;
+      groupMembers.putIfAbsent(groupId, () => {}).add(entryId);
+    }
+
+    _groupsById.clear();
+    for (final map in maps) {
+      final tempGroup = EntryGroup.fromMap(map);
+      // Hydrate with member IDs
+      final memberIds = groupMembers[tempGroup.id] ?? {};
+      final group = tempGroup.copyWith(memberIds: memberIds);
+      _groupsById[group.id!] = group;
+    }
+
+    _isInitialized = true;
+  }
+
+  Future<int> _saveGroupToDb(EntryGroup group, List<AvesEntry> members) async {
+    // Insert group
+    final groupId = await localMediaDb.insertEntryGroup(group.toMap());
+
+    // Insert members
+    for (int i = 0; i < members.length; i++) {
+      await localMediaDb.insertEntryGroupMember(groupId, members[i].id, i);
+    }
+
+    return groupId;
+  }
+
+  Future<void> _updateGroupInDb(EntryGroup group) async {
+    await localMediaDb.updateEntryGroup(group.toMap());
+  }
+
+  Future<void> _deleteGroupFromDb(int groupId) async {
+    await localMediaDb.deleteEntryGroup(groupId);
+  }
+
+  Future<void> _addMembersToDb(int groupId, List<AvesEntry> entries) async {
+    final currentCount = await localMediaDb.getEntryGroupMemberCount(groupId);
+    for (int i = 0; i < entries.length; i++) {
+      await localMediaDb.insertEntryGroupMember(groupId, entries[i].id, currentCount + i);
+    }
+  }
+
+  Future<void> _removeMembersFromDb(int groupId, List<int> entryIds) async {
+    await localMediaDb.deleteEntryGroupMembers(groupId, entryIds);
+  }
+
+  Future<List<AvesEntry>> _loadGroupMembersFromDb(int groupId) async {
+    final maps = await localMediaDb.loadEntryGroupMembers(groupId);
+    return maps.map((map) => AvesEntry.fromMap(map)).toList();
+  }
+}
+
+// Events
+
+class EntryGroupCreatedEvent {
+  final EntryGroup group;
+  EntryGroupCreatedEvent(this.group);
+}
+
+class EntryGroupUpdatedEvent {
+  final EntryGroup group;
+  EntryGroupUpdatedEvent(this.group);
+}
+
+class EntryGroupDeletedEvent {
+  final EntryGroup group;
+  EntryGroupDeletedEvent(this.group);
+}
+
+class EntryGroupMembersAddedEvent {
+  final EntryGroup group;
+  final List<AvesEntry> addedEntries;
+  EntryGroupMembersAddedEvent(this.group, this.addedEntries);
+}
+
+class EntryGroupMembersRemovedEvent {
+  final EntryGroup group;
+  final List<int> removedEntryIds;
+  EntryGroupMembersRemovedEvent(this.group, this.removedEntryIds);
+}
+
+/// Global instance of the entry group service
+final entryGroupService = EntryGroupService();

--- a/lib/services/common/entry_group_test_helper.dart
+++ b/lib/services/common/entry_group_test_helper.dart
@@ -1,0 +1,178 @@
+import 'package:aves/model/entry/entry.dart';
+import 'package:aves/services/common/entry_group_service.dart';
+import 'package:flutter/foundation.dart';
+
+/// Test helper for manual photo grouping feature.
+/// Use this to verify database integration is working.
+class EntryGroupTestHelper {
+  static final entryGroupService = EntryGroupService();
+
+  /// Creates a test group with the given entries
+  static Future<void> createTestGroup(List<AvesEntry> entries) async {
+    if (entries.length < 2) {
+      debugPrint('❌ Need at least 2 entries to create a group');
+      return;
+    }
+
+    try {
+      final group = await entryGroupService.createGroup(
+        name: 'Test Group ${DateTime.now().millisecondsSinceEpoch}',
+        entries: entries,
+      );
+
+      debugPrint('✅ Created group: ${group.name} (ID: ${group.id}) with ${group.memberCount} photos');
+    } catch (e) {
+      debugPrint('❌ Error creating group: $e');
+    }
+  }
+
+  /// Lists all existing groups
+  static Future<void> listAllGroups() async {
+    try {
+      final groups = await entryGroupService.getAllGroups();
+      debugPrint('📚 Total groups: ${groups.length}');
+
+      for (final group in groups) {
+        debugPrint('  - ${group.name} (ID: ${group.id}, Members: ${group.memberCount})');
+      }
+    } catch (e) {
+      debugPrint('❌ Error listing groups: $e');
+    }
+  }
+
+  /// Loads members for a specific group
+  static Future<void> loadGroupMembers(int groupId) async {
+    try {
+      final members = await entryGroupService.getGroupMembers(groupId);
+      debugPrint('👥 Group $groupId has ${members.length} members:');
+
+      for (final member in members) {
+        debugPrint('  - ${member.bestTitle} (ID: ${member.id})');
+      }
+    } catch (e) {
+      debugPrint('❌ Error loading members: $e');
+    }
+  }
+
+  /// Adds entries to an existing group
+  static Future<void> addToGroup(int groupId, List<AvesEntry> entries) async {
+    try {
+      await entryGroupService.addEntriesToGroup(
+        groupId: groupId,
+        entries: entries,
+      );
+      debugPrint('✅ Added ${entries.length} entries to group $groupId');
+    } catch (e) {
+      debugPrint('❌ Error adding to group: $e');
+    }
+  }
+
+  /// Removes entries from a group
+  static Future<void> removeFromGroup(int groupId, List<int> entryIds) async {
+    try {
+      await entryGroupService.removeEntriesFromGroup(
+        groupId: groupId,
+        entryIds: entryIds,
+      );
+      debugPrint('✅ Removed ${entryIds.length} entries from group $groupId');
+    } catch (e) {
+      debugPrint('❌ Error removing from group: $e');
+    }
+  }
+
+  /// Renames a group
+  static Future<void> renameGroup(int groupId, String newName) async {
+    try {
+      await entryGroupService.renameGroup(groupId, newName);
+      debugPrint('✅ Renamed group $groupId to "$newName"');
+    } catch (e) {
+      debugPrint('❌ Error renaming group: $e');
+    }
+  }
+
+  /// Deletes a group
+  static Future<void> deleteGroup(int groupId) async {
+    try {
+      await entryGroupService.deleteGroup(groupId);
+      debugPrint('✅ Deleted group $groupId');
+    } catch (e) {
+      debugPrint('❌ Error deleting group: $e');
+    }
+  }
+
+  /// Complete test flow
+  static Future<void> runFullTest(List<AvesEntry> testEntries) async {
+    debugPrint('\n🧪 Starting Entry Group Test...\n');
+
+    // Step 1: List existing groups
+    debugPrint('Step 1: List existing groups');
+    await listAllGroups();
+    debugPrint('');
+
+    // Step 2: Create a test group
+    if (testEntries.length >= 3) {
+      debugPrint('Step 2: Create test group with 3 photos');
+      await createTestGroup(testEntries.take(3).toList());
+      debugPrint('');
+
+      // Step 3: List groups again
+      debugPrint('Step 3: Verify group was created');
+      final groups = await entryGroupService.getAllGroups();
+      if (groups.isNotEmpty) {
+        final latestGroup = groups.first;
+        debugPrint('✅ Latest group: ${latestGroup.name} (ID: ${latestGroup.id})');
+        debugPrint('');
+
+        // Step 4: Load members
+        debugPrint('Step 4: Load group members');
+        await loadGroupMembers(latestGroup.id!);
+        debugPrint('');
+
+        // Step 5: Add more members (if available)
+        if (testEntries.length >= 5) {
+          debugPrint('Step 5: Add 2 more photos to group');
+          await addToGroup(latestGroup.id!, testEntries.skip(3).take(2).toList());
+          await loadGroupMembers(latestGroup.id!);
+          debugPrint('');
+        }
+
+        // Step 6: Rename
+        debugPrint('Step 6: Rename group');
+        await renameGroup(latestGroup.id!, 'My Renamed Test Group');
+        await listAllGroups();
+        debugPrint('');
+
+        // Step 7: Remove a member
+        if (testEntries.isNotEmpty) {
+          debugPrint('Step 7: Remove one photo from group');
+          await removeFromGroup(latestGroup.id!, [testEntries.first.id]);
+          await loadGroupMembers(latestGroup.id!);
+          debugPrint('');
+        }
+
+        // Step 8: Clean up (optional - comment out to keep test group)
+        // debugPrint('Step 8: Delete test group');
+        // await deleteGroup(latestGroup.id!);
+        // await listAllGroups();
+        // debugPrint('');
+
+        debugPrint('✅ Test completed successfully!\n');
+      }
+    } else {
+      debugPrint('❌ Need at least 5 entries to run full test\n');
+    }
+  }
+}
+
+/// Example usage in a widget:
+///
+/// ```dart
+/// FloatingActionButton(
+///   onPressed: () async {
+///     final entries = collection.sortedEntries.take(5).toList();
+///     await EntryGroupTestHelper.runFullTest(entries);
+///   },
+///   child: Icon(Icons.science),
+///   tooltip: 'Test Entry Groups',
+/// )
+/// ```

--- a/lib/theme/icons.dart
+++ b/lib/theme/icons.dart
@@ -141,6 +141,7 @@ class AIcons {
   static const rotateScreen = Symbols.screen_rotation;
   static const search = Symbols.search;
   static const select = Symbols.select_all;
+  static const ungroup = Symbols.layers_clear;
   static const setAs = Symbols.wallpaper;
   static final setBoundEnd = MdiIcons.rayEnd;
   static final setBoundStart = MdiIcons.rayStart;

--- a/lib/view/src/actions/entry_set.dart
+++ b/lib/view/src/actions/entry_set.dart
@@ -46,6 +46,10 @@ extension ExtraEntrySetActionView on EntrySetAction {
       EntrySetAction.editRating => l10n.entryInfoActionEditRating,
       EntrySetAction.editTags => l10n.entryInfoActionEditTags,
       EntrySetAction.removeMetadata => l10n.entryInfoActionRemoveMetadata,
+      EntrySetAction.group => l10n.entryActionGroup,
+      EntrySetAction.renameGroup => l10n.chipActionRename,
+      EntrySetAction.ungroup => l10n.entryActionUngroup,
+      EntrySetAction.removeFromGroup => l10n.entryActionRemoveFromGroup,
     };
   }
 
@@ -92,6 +96,10 @@ extension ExtraEntrySetActionView on EntrySetAction {
       EntrySetAction.editRating => AIcons.rating,
       EntrySetAction.editTags => AIcons.tag,
       EntrySetAction.removeMetadata => AIcons.clear,
+      EntrySetAction.group => AIcons.group,
+      EntrySetAction.renameGroup => AIcons.rename,
+      EntrySetAction.ungroup => AIcons.ungroup,
+      EntrySetAction.removeFromGroup => AIcons.remove,
     };
   }
 }

--- a/lib/widgets/aves_app.dart
+++ b/lib/widgets/aves_app.dart
@@ -19,6 +19,7 @@ import 'package:aves/model/source/collection_source.dart';
 import 'package:aves/model/source/media_store_source.dart';
 import 'package:aves/ref/locales.dart';
 import 'package:aves/services/accessibility_service.dart';
+import 'package:aves/services/common/entry_group_service.dart';
 import 'package:aves/services/common/services.dart';
 import 'package:aves/theme/colors.dart';
 import 'package:aves/theme/icons.dart';
@@ -515,6 +516,7 @@ class _AvesAppState extends State<AvesApp> with WidgetsBindingObserver {
     unawaited(storageService.deleteTempDirectory());
     unawaited(_setupErrorReporting());
 
+    unawaited(entryGroupService.getAllGroups());
     debugPrint('App setup in ${stopwatch.elapsed.inMilliseconds}ms');
   }
 

--- a/lib/widgets/collection/app_bar.dart
+++ b/lib/widgets/collection/app_bar.dart
@@ -5,6 +5,7 @@ import 'package:aves/app_mode.dart';
 import 'package:aves/model/entry/entry.dart';
 import 'package:aves/model/filters/container/dynamic_album.dart';
 import 'package:aves/model/filters/container/set_and.dart';
+
 import 'package:aves/model/filters/filters.dart';
 import 'package:aves/model/filters/query.dart';
 import 'package:aves/model/filters/trash.dart';
@@ -362,6 +363,7 @@ class _CollectionAppBarState extends State<CollectionAppBar> with RouteAware, Si
           isSelecting: isSelecting,
           collection: collection,
           selectedItemCount: selectedItemCount,
+          selection: selection,
         );
 
     return settings.useTvLayout
@@ -745,6 +747,7 @@ class _CollectionAppBarState extends State<CollectionAppBar> with RouteAware, Si
       case EntrySetAction.editRating:
       case EntrySetAction.editTags:
       case EntrySetAction.removeMetadata:
+      default:
         _actionDelegate.onActionSelected(context, action);
     }
   }

--- a/lib/widgets/collection/entry_set_action_delegate.dart
+++ b/lib/widgets/collection/entry_set_action_delegate.dart
@@ -11,6 +11,7 @@ import 'package:aves/model/entry/extensions/props.dart';
 import 'package:aves/model/favourites.dart';
 import 'package:aves/model/filters/container/dynamic_album.dart';
 import 'package:aves/model/filters/container/set_and.dart';
+import 'package:aves/model/filters/entry_group.dart';
 import 'package:aves/model/filters/filters.dart';
 import 'package:aves/model/grouping/common.dart';
 import 'package:aves/model/highlight.dart';
@@ -26,6 +27,7 @@ import 'package:aves/model/vaults/vaults.dart';
 import 'package:aves/services/app_service.dart';
 import 'package:aves/services/common/image_op_events.dart';
 import 'package:aves/services/common/services.dart';
+import 'package:aves/services/common/entry_group_service.dart';
 import 'package:aves/services/media/media_edit_service.dart';
 import 'package:aves/theme/durations.dart';
 import 'package:aves/theme/themes.dart';
@@ -119,9 +121,16 @@ class EntrySetActionDelegate with FeedbackMixin, PermissionAwareMixin, SizeAware
       case EntrySetAction.editRating:
       case EntrySetAction.editTags:
       case EntrySetAction.removeMetadata:
-        return isMain && isSelecting && !isTrash && canWrite;
+      case EntrySetAction.group:
+      case EntrySetAction.renameGroup:
+      case EntrySetAction.ungroup:
+      case EntrySetAction.removeFromGroup:
+        if (isSelecting) return isMain && !isTrash && canWrite;
+        return isMain && !isTrash && !useTvLayout;
       case EntrySetAction.restore:
         return isMain && isSelecting && isTrash && canWrite;
+      default:
+        return false;
     }
   }
 
@@ -130,6 +139,7 @@ class EntrySetActionDelegate with FeedbackMixin, PermissionAwareMixin, SizeAware
     required bool isSelecting,
     required CollectionLens collection,
     required int selectedItemCount,
+    Selection<AvesEntry>? selection,
   }) {
     final itemCount = collection.entryCount;
     final hasItems = itemCount > 0;
@@ -176,7 +186,25 @@ class EntrySetActionDelegate with FeedbackMixin, PermissionAwareMixin, SizeAware
       case EntrySetAction.editRating:
       case EntrySetAction.editTags:
       case EntrySetAction.removeMetadata:
+      case EntrySetAction.group:
         return hasSelection;
+      case EntrySetAction.removeFromGroup:
+        // Selecting items that belong to a group
+        if (isSelecting && selection != null) {
+          final service = EntryGroupService();
+          return selection.selectedItems.any((entry) => service.cachedGroups.any((g) => g.memberIds.contains(entry.id)) && entry.stackedEntries == null);
+        }
+        return false;
+      case EntrySetAction.renameGroup:
+      case EntrySetAction.ungroup:
+        // Either filtered by a group, OR selecting a group tile
+        if (!isSelecting && collection.filters.any((f) => f is EntryGroupFilter)) return true;
+        if (isSelecting && selection != null) {
+          return selection.selectedItems.any((entry) => entry.entryGroup != null && entry.stackedEntries != null);
+        }
+        return false;
+      default:
+        return false;
     }
   }
 
@@ -247,6 +275,16 @@ class EntrySetActionDelegate with FeedbackMixin, PermissionAwareMixin, SizeAware
         _editTags(context);
       case EntrySetAction.removeMetadata:
         _removeMetadata(context);
+      case EntrySetAction.group:
+        _group(context);
+      case EntrySetAction.renameGroup:
+        _renameGroup(context);
+      case EntrySetAction.ungroup:
+        _ungroup(context);
+      case EntrySetAction.removeFromGroup:
+        _removeFromGroup(context);
+      default:
+        break;
     }
   }
 
@@ -880,6 +918,181 @@ class EntrySetActionDelegate with FeedbackMixin, PermissionAwareMixin, SizeAware
 
   void _setHome(BuildContext context) async {
     settings.setHome(HomePageSetting.collection, customCollection: context.read<CollectionLens>().filters);
+    showFeedback(context, FeedbackType.info, context.l10n.genericSuccessFeedback);
+  }
+
+  Future<void> _group(BuildContext context) async {
+    final entries = _getTargetItems(context).toList();
+    if (entries.isEmpty) return;
+
+    final nameController = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+        return AvesDialog(
+          title: l10n.newGroupDialogTitle,
+          content: TextField(
+            controller: nameController,
+            autofocus: true,
+            decoration: InputDecoration(
+              labelText: l10n.newGroupDialogNameLabel,
+            ),
+          ),
+          actions: [
+            const CancelButton(),
+            TextButton(
+              onPressed: () => Navigator.maybeOf(context)?.pop(nameController.text),
+              child: Text(l10n.applyButtonLabel),
+            ),
+          ],
+        );
+      },
+    );
+    if (name == null || name.isEmpty) return;
+
+    final service = EntryGroupService();
+    try {
+      await service.createGroup(name: name, entries: entries);
+      context.read<CollectionLens>().refresh();
+      _browse(context);
+      showFeedback(context, FeedbackType.info, 'Created group "$name"');
+    } catch (e, stack) {
+      debugPrint('Failed to create group: $e\n$stack');
+      showFeedback(context, FeedbackType.warn, 'Failed to create group: $e');
+    }
+  }
+
+  Future<void> _removeFromGroup(BuildContext context) async {
+    final entries = _getTargetItems(context).toList();
+    if (entries.isEmpty) return;
+
+    final collection = context.read<CollectionLens>();
+    final groupFilter = collection.filters.whereType<EntryGroupFilter>().firstOrNull;
+
+    final service = EntryGroupService();
+    if (groupFilter != null) {
+      await service.removeEntriesFromGroup(
+        groupId: groupFilter.groupId,
+        entryIds: entries.map((e) => e.id).toList(),
+      );
+    } else {
+      for (final entry in entries) {
+        final groupIds = service.cachedGroups.where((g) => g.memberIds.contains(entry.id)).map((g) => g.id!).toList();
+        for (final groupId in groupIds) {
+          await service.removeEntriesFromGroup(
+            groupId: groupId,
+            entryIds: [entry.id],
+          );
+        }
+      }
+    }
+
+    collection.refresh();
+    _browse(context);
+    showFeedback(context, FeedbackType.info, context.l10n.genericSuccessFeedback);
+  }
+
+  Future<void> _ungroup(BuildContext context) async {
+    final collection = context.read<CollectionLens>();
+    final selection = context.read<Selection<AvesEntry>>();
+
+    final groupIds = <int>{};
+    if (selection.isSelecting) {
+      groupIds.addAll(selection.selectedItems.map((e) => e.entryGroup?.id).whereType<int>());
+    } else {
+      final groupFilter = collection.filters.whereType<EntryGroupFilter>().firstOrNull;
+      if (groupFilter != null) groupIds.add(groupFilter.groupId);
+    }
+
+    if (groupIds.isEmpty) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+        return AvesDialog(
+          content: Text('Are you sure you want to ungroup ${groupIds.length == 1 ? 'this group' : 'these groups'}? The photos will remain in the gallery.'),
+          actions: [
+            const CancelButton(),
+            TextButton(
+              onPressed: () => Navigator.maybeOf(context)?.pop(true),
+              child: Text(l10n.applyButtonLabel),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) return;
+
+    final service = EntryGroupService();
+    for (final groupId in groupIds) {
+      await service.deleteGroup(groupId);
+    }
+
+    if (selection.isSelecting) {
+      _browse(context);
+    } else {
+      Navigator.maybeOf(context)?.pop();
+    }
+    collection.refresh();
+    showFeedback(context, FeedbackType.info, 'Ungrouped successfully');
+  }
+
+  Future<void> _renameGroup(BuildContext context) async {
+    final collection = context.read<CollectionLens>();
+    final selection = context.read<Selection<AvesEntry>>();
+
+    int? groupId;
+    String? oldName;
+    EntryGroupFilter? groupFilter;
+
+    if (selection.isSelecting) {
+      final groupEntry = selection.selectedItems.firstWhereOrNull((e) => e.entryGroup != null);
+      groupId = groupEntry?.entryGroup?.id;
+      oldName = groupEntry?.entryGroup?.name;
+    } else {
+      groupFilter = collection.filters.whereType<EntryGroupFilter>().firstOrNull;
+      groupId = groupFilter?.groupId;
+      oldName = groupFilter?.groupName;
+    }
+
+    if (groupId == null || oldName == null) return;
+
+    final nameController = TextEditingController(text: oldName);
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+        return AvesDialog(
+          title: l10n.chipActionRename,
+          content: TextField(
+            controller: nameController,
+            autofocus: true,
+          ),
+          actions: [
+            const CancelButton(),
+            TextButton(
+              onPressed: () => Navigator.maybeOf(context)?.pop(nameController.text),
+              child: Text(l10n.applyButtonLabel),
+            ),
+          ],
+        );
+      },
+    );
+    if (newName == null || newName.isEmpty || newName == oldName) return;
+
+    final service = EntryGroupService();
+    await service.renameGroup(groupId, newName);
+
+    if (groupFilter != null) {
+      collection.removeFilter(groupFilter);
+      collection.addFilters({EntryGroupFilter(groupId, newName)});
+    } else if (selection.isSelecting) {
+      _browse(context);
+    }
+    collection.refresh();
+
     showFeedback(context, FeedbackType.info, context.l10n.genericSuccessFeedback);
   }
 }

--- a/lib/widgets/collection/grid/group_tile.dart
+++ b/lib/widgets/collection/grid/group_tile.dart
@@ -1,0 +1,269 @@
+import 'package:aves/model/entry/entry.dart';
+import 'package:aves/model/entry/entry_group.dart';
+import 'package:aves/widgets/common/thumbnail/image.dart';
+import 'package:flutter/material.dart';
+
+/// A tile widget that represents a photo group in the gallery grid.
+/// Displays a cover photo, stack icon with count, and optional group name.
+class GroupTile extends StatelessWidget {
+  final EntryGroup group;
+  final double extent;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+  final AvesEntry? coverEntryOverride;
+
+  const GroupTile({
+    super.key,
+    required this.group,
+    required this.extent,
+    this.onTap,
+    this.onLongPress,
+    this.coverEntryOverride,
+    this.isSelected = false,
+  });
+
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final coverEntry = coverEntryOverride ?? group.coverEntry;
+    if (coverEntry == null) {
+      return _buildEmptyTile(context);
+    }
+
+    final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
+
+    return GestureDetector(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Stack(
+        children: [
+          // Background "sheets" to create a stack effect
+          Positioned.fill(
+            child: Padding(
+              padding: const EdgeInsets.all(4.0),
+              child: Transform.rotate(
+                angle: 0.05,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary.withValues(alpha: .2),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Theme.of(context).colorScheme.primary.withValues(alpha: .3), width: 1),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned.fill(
+            child: Padding(
+              padding: const EdgeInsets.all(2.0),
+              child: Transform.rotate(
+                angle: -0.03,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary.withValues(alpha: .4),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Theme.of(context).colorScheme.primary.withValues(alpha: .5), width: 1),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          // Main tile
+          Container(
+            width: extent,
+            height: extent,
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: isSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.primary.withValues(alpha: .8),
+                width: isSelected ? 4.0 : 2.5,
+              ),
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: .2),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  // Cover photo
+                  ThumbnailImage(
+                    entry: coverEntry,
+                    extent: extent,
+                    devicePixelRatio: devicePixelRatio,
+                  ),
+
+                  // Subtle gradient overlay for better text/icon visibility
+                  Positioned.fill(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topRight,
+                          end: Alignment.bottomLeft,
+                          colors: [
+                            Colors.black.withValues(alpha: .3),
+                            Colors.transparent,
+                            Colors.black.withValues(alpha: .3),
+                          ],
+                          stops: const [0.0, 0.5, 1.0],
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  // Group icon (top-right)
+                  Positioned(
+                    top: 6,
+                    right: 6,
+                    child: Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: .5),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.layers_rounded,
+                        size: 16,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+
+                  // Group name label (bottom)
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: _buildNameLabel(context),
+                  ),
+
+                  if (isSelected)
+                    Positioned.fill(
+                      child: Container(
+                        color: Theme.of(context).colorScheme.primary.withValues(alpha: .4),
+                        child: const Center(
+                          child: Icon(
+                            Icons.check_circle,
+                            color: Colors.white,
+                            size: 40,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNameLabel(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.bottomCenter,
+          end: Alignment.topCenter,
+          colors: [
+            Colors.black.withOpacity(0.7),
+            Colors.black.withOpacity(0.0),
+          ],
+        ),
+      ),
+      child: Text(
+        group.name,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+          shadows: [
+            Shadow(
+              offset: Offset(0, 1),
+              blurRadius: 2,
+              color: Colors.black54,
+            ),
+          ],
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  Widget _buildEmptyTile(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: Transform.rotate(
+              angle: 0.05,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary.withValues(alpha: .1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Container(
+          width: extent,
+          height: extent,
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: .5),
+              width: 2.5,
+            ),
+            borderRadius: BorderRadius.circular(8),
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          ),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.layers_outlined,
+                  size: 32,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  group.name,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Example usage in the collection grid
+///
+/// Widget _buildGridItem(GridItem item) {
+///   if (item is SingleEntryItem) {
+///     return ThumbnailTile(entry: item.entry, extent: extent);
+///   } else if (item is GroupItem) {
+///     return GroupTile(
+///       group: item.group,
+///       extent: extent,
+///       onTap: () => _openGroupViewer(item.group),
+///       onLongPress: () => _showGroupContextMenu(item.group),
+///     );
+///   }
+///   return const SizedBox.shrink();
+/// }

--- a/lib/widgets/collection/grid/tile.dart
+++ b/lib/widgets/collection/grid/tile.dart
@@ -1,10 +1,14 @@
 import 'package:aves/app_mode.dart';
+import 'package:aves/model/source/collection_source.dart';
+import 'package:aves/widgets/collection/collection_page.dart';
 import 'package:aves/model/entry/entry.dart';
 import 'package:aves/model/selection.dart';
+import 'package:aves/model/filters/entry_group.dart';
 import 'package:aves/model/source/collection_lens.dart';
 import 'package:aves/services/intent_service.dart';
 import 'package:aves/widgets/collection/grid/list_details.dart';
 import 'package:aves/widgets/collection/grid/list_details_theme.dart';
+import 'package:aves/widgets/collection/grid/group_tile.dart';
 import 'package:aves/widgets/common/grid/scaling.dart';
 import 'package:aves/widgets/common/providers/viewer_entry_provider.dart';
 import 'package:aves/widgets/common/thumbnail/decorated.dart';
@@ -32,6 +36,36 @@ class InteractiveTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (entry.entryGroup != null && entry.stackedEntries != null) {
+      final selection = context.watch<Selection<AvesEntry>>();
+      final isSelecting = selection.isSelecting;
+      final isSelected = selection.selectedItems.contains(entry);
+
+      return GroupTile(
+        group: entry.entryGroup!,
+        extent: thumbnailExtent,
+        coverEntryOverride: entry,
+        isSelected: isSelected,
+        onTap: () {
+          if (isSelecting) {
+            selection.toggleSelection(entry);
+          } else {
+            final source = context.read<CollectionSource>();
+            final filter = EntryGroupFilter(entry.entryGroup!.id!, entry.entryGroup!.name);
+            Navigator.maybeOf(context)?.push(
+              MaterialPageRoute(
+                settings: const RouteSettings(name: CollectionPage.routeName),
+                builder: (context) => CollectionPage(
+                  source: source,
+                  filters: {filter},
+                ),
+              ),
+            );
+          }
+        },
+        onLongPress: () => selection.toggleSelection(entry),
+      );
+    }
     return InkWell(
       onTap: () {
         final appMode = context.read<ValueNotifier<AppMode>>().value;

--- a/plugins/aves_model/lib/src/actions/entry_set.dart
+++ b/plugins/aves_model/lib/src/actions/entry_set.dart
@@ -25,6 +25,10 @@ enum EntrySetAction {
   rename,
   convert,
   toggleFavourite,
+  group,
+  renameGroup,
+  ungroup,
+  removeFromGroup,
   rotateCCW,
   rotateCW,
   flip,
@@ -57,6 +61,8 @@ class EntrySetActions {
     EntrySetAction.stats,
     null,
     EntrySetAction.rescan,
+    EntrySetAction.renameGroup,
+    EntrySetAction.ungroup,
     EntrySetAction.emptyBin,
   ];
 
@@ -81,6 +87,10 @@ class EntrySetActions {
     EntrySetAction.rename,
     EntrySetAction.convert,
     EntrySetAction.toggleFavourite,
+    EntrySetAction.group,
+    EntrySetAction.renameGroup,
+    EntrySetAction.ungroup,
+    EntrySetAction.removeFromGroup,
     null,
     EntrySetAction.map,
     EntrySetAction.slideshow,
@@ -125,5 +135,6 @@ class EntrySetActions {
     EntrySetAction.editRating,
     EntrySetAction.editTags,
     EntrySetAction.removeMetadata,
+    EntrySetAction.removeFromGroup,
   ];
 }


### PR DESCRIPTION
Closes #1885

# Manual Photo Grouping

This PR introduces a manual photo grouping feature, allowing users to stack photos into custom groups that stay pinned at the top of the gallery. This makes it easy to categorize event photos, sellable items, or receipts without cluttering the main timeline.

## 🚀 Key Features
- **3D Stack Visuals**: Grouped photos are represented by a premium "Stacked" tile with offset background layers and a subtle shadow, creating a physical "pile of photos" look.
- **Top-of-Gallery Pinning**: All manual groups are automatically pinned to the beginning of the grid for instant access icon.
- **Intelligent Navigation**:
  - Tapping a group enters a "Simple View" showing all member photos individually.
  - The App Bar remains consistent with the library title to avoid UI jumping.

- **Context-Aware Menus**:
  - Selecting a Group Folder provides an **Ungroup** option.
  - Selecting items inside an open group provides a **Remove from Group** option.
- **Robust Backend**:
  - Optimized **O(n) stacking logic** for smooth performance even with thousands of photos.
  - SQLite foreign keys with `ON DELETE CASCADE` ensure database integrity when original photos are deleted.

## 🛠️ Technical Changes
- **Created [EntryGroupService](cci:2://file:///home/vivek/aves/lib/services/common/entry_group_service.dart:10:0-313:1)** for centralized CRUD operations and thread-safe caching.
- **Modified [CollectionLens](cci:2://file:///home/vivek/aves/lib/model/source/collection_lens.dart:31:0-495:1)** to implement pinned stacking logic.
- **Updated [GroupTile](cci:2://file:///home/vivek/aves/lib/widgets/collection/grid/group_tile.dart:7:0-252:1)** with a reactive design and custom selection animations.
- **Enhanced `SqfliteLocalMediaDb`** schema (**v17**) to support group metadata and member associations.


https://github.com/user-attachments/assets/301d2dcd-3253-4eb6-a2a6-8bff0ef8a7b1

