### PR TITLE
motion photo: detect JPEG with embedded MP4 video but no XMP

### DIFF
--- a/android/app/src/main/kotlin/deckers/thibault/aves/channel/calls/MetadataFetchHandler.kt
+++ b/android/app/src/main/kotlin/deckers/thibault/aves/channel/calls/MetadataFetchHandler.kt
@@ -864,6 +864,13 @@ class MetadataFetchHandler(private val context: Context) : MethodCallHandler {
 
         if (mimeType == MimeTypes.TIFF && MultiPage.isMultiPageTiff(context, uri)) flags = flags or MASK_IS_MULTIPAGE
 
+        // embedded MP4 video in JPEG without XMP (e.g. Xiaomi dynamic photos)
+        if (mimeType == MimeTypes.JPEG && (flags and MASK_IS_MOTION_PHOTO == 0) && sizeBytes != null) {
+            if (MultiPage.getTrailerVideoSize(context, uri, mimeType, sizeBytes) != null) {
+                flags = flags or MASK_IS_MULTIPAGE or MASK_IS_MOTION_PHOTO
+            }
+        }
+
         metadataMap[KEY_FLAGS] = flags
     }
 

--- a/android/app/src/main/kotlin/deckers/thibault/aves/metadata/MultiPage.kt
+++ b/android/app/src/main/kotlin/deckers/thibault/aves/metadata/MultiPage.kt
@@ -343,6 +343,27 @@ object MultiPage {
 
         XMP.checkIsoBMFFImage(context, mimeType, uri, foundXmp, ::processXmp)
 
+        // fallback for JPEG with embedded MP4 video but no XMP (e.g. Xiaomi dynamic photos)
+        // only scan files large enough to feasibly contain embedded video data
+        if (offsetFromEnd == null && mimeType == MimeTypes.JPEG && sizeBytes > 5_000_000) {
+            try {
+                Metadata.openSafeInputStream(context, uri, mimeType, sizeBytes)?.use { input ->
+                    if (MemoryUtils.canAllocate(sizeBytes)) {
+                        val bytes = ByteArray(sizeBytes.toInt())
+                        DataInputStream(input).use {
+                            it.readFully(bytes)
+                        }
+                        val index = bytes.indexOfBytes(heicMotionPhotoVideoStartIndicator)
+                        if (index != -1) {
+                            offsetFromEnd = sizeBytes - index
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(LOG_TAG, "failed to find embedded video in JPEG uri=$uri", e)
+            }
+        }
+
         return offsetFromEnd
     }
 


### PR DESCRIPTION
Xiaomi (and possibly other Android vendors) dynamic photos embed MP4 video directly in JPEG files without writing any XMP metadata (`GCamera:MicroVideoOffset` or `Container:Directory`). The existing detection relies solely on XMP markers, so these files are not recognized as motion photos.

## Changes

1. **`MultiPage.getTrailerVideoSize()`** — add binary scan fallback for JPEG files >5MB. When XMP parsing yields no video offset, scan for the `ftypmp42` ISOBMFF marker in trailing data to locate the embedded MP4 video.

2. **`MetadataFetchHandler.getCatalogMetadataByMetadataExtractor()`** — after existing motion photo detection paths, check JPEG files via `getTrailerVideoSize()` and set `MASK_IS_MULTIPAGE | MASK_IS_MOTION_PHOTO` flags when an embedded video is found.

## Tested

- Xiaomi dynamic photos exported via WeChat (`mmexport*.jpg`) which contain MP4 video at the tail with no XMP markers
- The `ftypmp42` byte marker search reuses the existing `heicMotionPhotoVideoStartIndicator` constant used for HEIC fallback detection